### PR TITLE
Fixes bug with pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The information below is for developers looking to contribute to the openFramewo
 To learn about how to get started with openFrameworks using Visual Studio check http://openframeworks.cc/setup/vs.
 ```
 
-To develop this solution further, clone the repo and open /src/VSIXopenFrameworks.sln in Visual Studio.
+To develop this solution further, clone the repo and open `/src/VSIXopenFrameworks.sln` in Visual Studio.
 
 Running the **VSIXopenFrameworks** project (right-click, Debug, or F5) will start the experimental version of Visual Studio, 
 which will run having the Visual Studio Extension (vsix) already loaded.

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VSIXopenframeworks2017.A049B6B4-2855-4C1C-A3A6-13ED823BB898" Version="0.6" Language="en-US" Publisher="Arturo Castro, Half Scheidl" />
+        <Identity Id="VSIXopenframeworks2017.A049B6B4-2855-4C1C-A3A6-13ED823BB898" Version="0.7" Language="en-US" Publisher="Arturo Castro, Half Scheidl" />
         <DisplayName>openFrameworks plugin for Visual Studio 2017</DisplayName>
         <Description xml:space="preserve">openFrameworks plugin for Visual Studio 2017</Description>
         <MoreInfo>https://openframeworks.cc/</MoreInfo>
@@ -25,7 +25,7 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="15.6" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.VC.CoreIde" Version="15.6" DisplayName="Visual Studio C++ core features" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.6.27309.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.VC.CoreIde" Version="[15.6.27406.0,16.0)" DisplayName="Visual Studio C++ core features" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
The latest PR introduced a bug which made the extension limited to a specific build of Visual Studio. This was fixed by extending the version range in the pre-requisites.